### PR TITLE
AltID

### DIFF
--- a/cmd/lambda_worker/main.go
+++ b/cmd/lambda_worker/main.go
@@ -176,6 +176,7 @@ func arweave_bundle_single(pc *model.ProofChain, previous *model.ProofChain) (*a
 		Action:            pc.Action,
 		Platform:          pc.Platform,
 		Identity:          pc.Identity,
+		AltID:             pc.AltID,
 		ProofLocation:     pc.Location,
 		CreatedAt:         strconv.FormatInt(pc.CreatedAt.Unix(), 10),
 		Signature:         pc.Signature,

--- a/controller/proof_exists.go
+++ b/controller/proof_exists.go
@@ -42,9 +42,10 @@ func proofExists(c *gin.Context) {
 	}
 	found := model.Proof{}
 	tx := model.DB.Where(
-		"persona = ? AND platform = ? AND identity = ?",
+		"persona = ? AND platform = ? AND (identity = ? OR alt_name = ?)",
 		model.MarshalPersona(personaPubkey),
 		req.Platform,
+		strings.ToLower(req.Identity),
 		strings.ToLower(req.Identity),
 	).Find(&found)
 

--- a/controller/proof_exists.go
+++ b/controller/proof_exists.go
@@ -42,7 +42,7 @@ func proofExists(c *gin.Context) {
 	}
 	found := model.Proof{}
 	tx := model.DB.Where(
-		"persona = ? AND platform = ? AND (identity = ? OR alt_name = ?)",
+		"persona = ? AND platform = ? AND (identity = ? OR alt_id = ?)",
 		model.MarshalPersona(personaPubkey),
 		req.Platform,
 		strings.ToLower(req.Identity),

--- a/controller/proof_query.go
+++ b/controller/proof_query.go
@@ -149,7 +149,7 @@ func performProofQuery(req ProofQueryRequest) ([]ProofQueryResponseSingle, Proof
 				return ProofQueryResponseSingleProof{
 					Platform:      proof.Platform,
 					Identity:      proof.Identity,
-					AltName:       proof.AltName,
+					AltName:       proof.AltID,
 					CreatedAt:     strconv.FormatInt(proof.CreatedAt.Unix(), 10),
 					LastCheckedAt: strconv.FormatInt(proof.LastCheckedAt.Unix(), 10),
 					IsValid:       proof.IsValid,

--- a/controller/proof_query.go
+++ b/controller/proof_query.go
@@ -45,6 +45,7 @@ type ProofQueryResponseSingle struct {
 type ProofQueryResponseSingleProof struct {
 	Platform      types.Platform `json:"platform"`
 	Identity      string         `json:"identity"`
+	AltName       string         `json:"alt_name"`
 	CreatedAt     string         `json:"created_at"`
 	LastCheckedAt string         `json:"last_checked_at"`
 	IsValid       bool           `json:"is_valid"`
@@ -94,12 +95,12 @@ func performProofQuery(req ProofQueryRequest) ([]ProofQueryResponseSingle, Proof
 		}
 	case "":
 		{ // All platform
-			tx = tx.Where("identity LIKE ?", "%"+strings.ToLower(req.Identity[0])+"%")
+			tx = tx.Where("identity LIKE ? OR alt_name LIKE ?", "%"+strings.ToLower(req.Identity[0])+"%", "%"+strings.ToLower(req.Identity[0])+"%")
 			for i, id := range req.Identity {
 				if i == 0 {
 					continue
 				}
-				tx = tx.Or("identity LIKE ?", "%"+strings.ToLower(id)+"%")
+				tx = tx.Or("identity LIKE ? OR alt_name LIKE ?", "%"+strings.ToLower(id)+"%", "%"+strings.ToLower(id)+"%")
 			}
 			countTx := tx // Value-copy another query for total amount calculation
 			countTx.Count(&pagination.Total)
@@ -108,13 +109,13 @@ func performProofQuery(req ProofQueryRequest) ([]ProofQueryResponseSingle, Proof
 	default:
 		{
 			tx = tx.Where("platform", req.Platform).
-				Where("identity LIKE ?", "%"+strings.ToLower(req.Identity[0])+"%")
+				Where("identity LIKE ? OR alt_name LIKE ?", "%"+strings.ToLower(req.Identity[0])+"%", "%"+strings.ToLower(req.Identity[0])+"%")
 
 			for i, id := range req.Identity {
 				if i == 0 {
 					continue
 				}
-				tx = tx.Or("identity LIKE ?", "%"+strings.ToLower(id)+"%")
+				tx = tx.Or("identity LIKE ? OR alt_name LIKE ?", "%"+strings.ToLower(id)+"%", "%"+strings.ToLower(id)+"%")
 			}
 			countTx := tx
 			countTx.Count(&pagination.Total)
@@ -148,6 +149,7 @@ func performProofQuery(req ProofQueryRequest) ([]ProofQueryResponseSingle, Proof
 				return ProofQueryResponseSingleProof{
 					Platform:      proof.Platform,
 					Identity:      proof.Identity,
+					AltName:       proof.AltName,
 					CreatedAt:     strconv.FormatInt(proof.CreatedAt.Unix(), 10),
 					LastCheckedAt: strconv.FormatInt(proof.LastCheckedAt.Unix(), 10),
 					IsValid:       proof.IsValid,

--- a/controller/proof_query.go
+++ b/controller/proof_query.go
@@ -45,7 +45,7 @@ type ProofQueryResponseSingle struct {
 type ProofQueryResponseSingleProof struct {
 	Platform      types.Platform `json:"platform"`
 	Identity      string         `json:"identity"`
-	AltName       string         `json:"alt_name"`
+	AltID         string         `json:"alt_id"`
 	CreatedAt     string         `json:"created_at"`
 	LastCheckedAt string         `json:"last_checked_at"`
 	IsValid       bool           `json:"is_valid"`
@@ -95,12 +95,12 @@ func performProofQuery(req ProofQueryRequest) ([]ProofQueryResponseSingle, Proof
 		}
 	case "":
 		{ // All platform
-			tx = tx.Where("identity LIKE ? OR alt_name LIKE ?", "%"+strings.ToLower(req.Identity[0])+"%", "%"+strings.ToLower(req.Identity[0])+"%")
+			tx = tx.Where("identity LIKE ? OR alt_id LIKE ?", "%"+strings.ToLower(req.Identity[0])+"%", "%"+strings.ToLower(req.Identity[0])+"%")
 			for i, id := range req.Identity {
 				if i == 0 {
 					continue
 				}
-				tx = tx.Or("identity LIKE ? OR alt_name LIKE ?", "%"+strings.ToLower(id)+"%", "%"+strings.ToLower(id)+"%")
+				tx = tx.Or("identity LIKE ? OR alt_id LIKE ?", "%"+strings.ToLower(id)+"%", "%"+strings.ToLower(id)+"%")
 			}
 			countTx := tx // Value-copy another query for total amount calculation
 			countTx.Count(&pagination.Total)
@@ -109,13 +109,13 @@ func performProofQuery(req ProofQueryRequest) ([]ProofQueryResponseSingle, Proof
 	default:
 		{
 			tx = tx.Where("platform", req.Platform).
-				Where("identity LIKE ? OR alt_name LIKE ?", "%"+strings.ToLower(req.Identity[0])+"%", "%"+strings.ToLower(req.Identity[0])+"%")
+				Where("identity LIKE ? OR alt_id LIKE ?", "%"+strings.ToLower(req.Identity[0])+"%", "%"+strings.ToLower(req.Identity[0])+"%")
 
 			for i, id := range req.Identity {
 				if i == 0 {
 					continue
 				}
-				tx = tx.Or("identity LIKE ? OR alt_name LIKE ?", "%"+strings.ToLower(id)+"%", "%"+strings.ToLower(id)+"%")
+				tx = tx.Or("identity LIKE ? OR alt_id LIKE ?", "%"+strings.ToLower(id)+"%", "%"+strings.ToLower(id)+"%")
 			}
 			countTx := tx
 			countTx.Count(&pagination.Total)
@@ -149,7 +149,7 @@ func performProofQuery(req ProofQueryRequest) ([]ProofQueryResponseSingle, Proof
 				return ProofQueryResponseSingleProof{
 					Platform:      proof.Platform,
 					Identity:      proof.Identity,
-					AltName:       proof.AltID,
+					AltID:         proof.AltID,
 					CreatedAt:     strconv.FormatInt(proof.CreatedAt.Unix(), 10),
 					LastCheckedAt: strconv.FormatInt(proof.LastCheckedAt.Unix(), 10),
 					IsValid:       proof.IsValid,

--- a/model/proof.go
+++ b/model/proof.go
@@ -25,6 +25,7 @@ type Proof struct {
 	Persona  string         `gorm:"index;not null"`
 	Platform types.Platform `gorm:"index;not null"`
 	Identity string         `gorm:"index;not null"`
+	AltName  string         `gorm:"index"`
 	Location string         `gorm:"not null"`
 }
 

--- a/model/proof.go
+++ b/model/proof.go
@@ -25,7 +25,7 @@ type Proof struct {
 	Persona  string         `gorm:"index;not null"`
 	Platform types.Platform `gorm:"index;not null"`
 	Identity string         `gorm:"index;not null"`
-	AltName  string         `gorm:"index"`
+	AltID    string         `gorm:"index"`
 	Location string         `gorm:"not null"`
 }
 

--- a/model/proof.go
+++ b/model/proof.go
@@ -25,7 +25,7 @@ type Proof struct {
 	Persona  string         `gorm:"index;not null"`
 	Platform types.Platform `gorm:"index;not null"`
 	Identity string         `gorm:"index;not null"`
-	AltID    string         `gorm:"index"`
+	AltID    string         `gorm:"column:alt_id;index"`
 	Location string         `gorm:"not null"`
 }
 

--- a/model/proof_chain.go
+++ b/model/proof_chain.go
@@ -25,7 +25,7 @@ type ProofChain struct {
 	Action           types.Action   `gorm:"index;not null"`
 	Persona          string         `gorm:"index;not null"`
 	Identity         string         `gorm:"index;not null"`
-	AltName          string         `gorm:"index"`
+	AltID            string         `gorm:"index"`
 	Platform         types.Platform `gorm:"index;not null"`
 	Location         string         `gorm:"not null"`
 	Signature        string         `gorm:"not null"`
@@ -118,7 +118,7 @@ func (pc *ProofChain) createProof() (err error) {
 		Persona:       pc.Persona,
 		Platform:      pc.Platform,
 		Identity:      pc.Identity,
-		AltName:       pc.AltName,
+		AltID:         pc.AltID,
 		Location:      pc.Location,
 		LastCheckedAt: time.Now(),
 		IsValid:       true,
@@ -177,7 +177,7 @@ func (pc *ProofChain) RestoreValidator() (v *validator.Base, err error) {
 		Action:        pc.Action,
 		Pubkey:        pc.Pubkey(),
 		Identity:      pc.Identity,
-		AltName:       pc.AltName,
+		AltID:         pc.AltID,
 		ProofLocation: pc.Location,
 		Signature:     pc.SignatureBytes(),
 		Extra:         extra,
@@ -238,7 +238,7 @@ func ProofChainCreateFromValidator(validator *validator.Base) (pc *ProofChain, e
 		Action:           validator.Action,
 		Persona:          MarshalPersona(validator.Pubkey),
 		Identity:         validator.Identity, // TODO: exception may occur
-		AltName:          validator.AltName,
+		AltID:            validator.AltID,
 		Platform:         validator.Platform,
 		Location:         validator.ProofLocation,
 		Signature:        MarshalSignature(validator.Signature),

--- a/model/proof_chain.go
+++ b/model/proof_chain.go
@@ -25,7 +25,7 @@ type ProofChain struct {
 	Action           types.Action   `gorm:"index;not null"`
 	Persona          string         `gorm:"index;not null"`
 	Identity         string         `gorm:"index;not null"`
-	AltID            string         `gorm:"index"`
+	AltID            string         `gorm:"column:alt_id;index"`
 	Platform         types.Platform `gorm:"index;not null"`
 	Location         string         `gorm:"not null"`
 	Signature        string         `gorm:"not null"`
@@ -42,6 +42,7 @@ type ProofChainItem struct {
 	Action           types.Action   `json:"action"`
 	Platform         types.Platform `json:"platform"`
 	Identity         string         `json:"identity"`
+	AltID            string         `json:"alt_id"`
 	ProofLocation    string         `json:"proof_location"`
 	CreatedAt        string         `json:"created_at"`
 	Signature        string         `json:"signature"`
@@ -57,6 +58,7 @@ type ProofChainArweaveDocument struct {
 	Action            types.Action   `json:"action"`
 	Platform          types.Platform `json:"platform"`
 	Identity          string         `json:"identity"`
+	AltID             string         `json:"alt_id"`
 	ProofLocation     string         `json:"proof_location"`
 	CreatedAt         string         `json:"created_at"`
 	Signature         string         `json:"signature"`
@@ -96,6 +98,7 @@ func (pc *ProofChain) ToProofChainItem() ProofChainItem {
 		Action:           pc.Action,
 		Platform:         pc.Platform,
 		Identity:         pc.Identity,
+		AltID:            pc.AltID,
 		ProofLocation:    pc.Location,
 		CreatedAt:        strconv.FormatInt(pc.CreatedAt.Unix(), 10),
 		Signature:        pc.Signature,

--- a/model/proof_chain.go
+++ b/model/proof_chain.go
@@ -25,6 +25,7 @@ type ProofChain struct {
 	Action           types.Action   `gorm:"index;not null"`
 	Persona          string         `gorm:"index;not null"`
 	Identity         string         `gorm:"index;not null"`
+	AltName          string         `gorm:"index"`
 	Platform         types.Platform `gorm:"index;not null"`
 	Location         string         `gorm:"not null"`
 	Signature        string         `gorm:"not null"`
@@ -117,6 +118,7 @@ func (pc *ProofChain) createProof() (err error) {
 		Persona:       pc.Persona,
 		Platform:      pc.Platform,
 		Identity:      pc.Identity,
+		AltName:       pc.AltName,
 		Location:      pc.Location,
 		LastCheckedAt: time.Now(),
 		IsValid:       true,
@@ -175,6 +177,7 @@ func (pc *ProofChain) RestoreValidator() (v *validator.Base, err error) {
 		Action:        pc.Action,
 		Pubkey:        pc.Pubkey(),
 		Identity:      pc.Identity,
+		AltName:       pc.AltName,
 		ProofLocation: pc.Location,
 		Signature:     pc.SignatureBytes(),
 		Extra:         extra,
@@ -235,6 +238,7 @@ func ProofChainCreateFromValidator(validator *validator.Base) (pc *ProofChain, e
 		Action:           validator.Action,
 		Persona:          MarshalPersona(validator.Pubkey),
 		Identity:         validator.Identity, // TODO: exception may occur
+		AltName:          validator.AltName,
 		Platform:         validator.Platform,
 		Location:         validator.ProofLocation,
 		Signature:        MarshalSignature(validator.Signature),

--- a/util/base1024/init.go
+++ b/util/base1024/init.go
@@ -20,7 +20,7 @@ func init() {
 	})
 
 	points := make([]int64, 1024)
-	for i, _ := range points {
+	for i := range points {
 		points[i] = 1
 	}
 

--- a/validator/das/das.go
+++ b/validator/das/das.go
@@ -101,7 +101,7 @@ func (das *Das) GenerateSignPayload() (payload string) {
 
 func (das *Das) Validate() (err error) {
 	das.Identity = strings.ToLower(das.Identity)
-	das.AltName = das.Identity
+	das.AltID = das.Identity
 	das.SignaturePayload = das.GenerateSignPayload()
 
 	// Find the record through API response instead of saving its 'location'.

--- a/validator/das/das.go
+++ b/validator/das/das.go
@@ -101,6 +101,7 @@ func (das *Das) GenerateSignPayload() (payload string) {
 
 func (das *Das) Validate() (err error) {
 	das.Identity = strings.ToLower(das.Identity)
+	das.AltName = das.Identity
 	das.SignaturePayload = das.GenerateSignPayload()
 
 	// Find the record through API response instead of saving its 'location'.

--- a/validator/das/das_test.go
+++ b/validator/das/das_test.go
@@ -53,7 +53,7 @@ func Test_Validate(t *testing.T) {
 		require.Nil(t, das.Validate())
 		require.Greater(t, len(das.Signature), 10)
 		require.Equal(t, "mitchatmask.bit", das.Identity)
-		require.Equal(t, das.Identity, das.AltName)
+		require.Equal(t, das.Identity, das.AltID)
 	})
 
 	// Do not test validation by ProofLocation, since it is unnecessary.

--- a/validator/das/das_test.go
+++ b/validator/das/das_test.go
@@ -9,7 +9,7 @@ import (
 	mycrypto "github.com/nextdotid/proof_server/util/crypto"
 	"github.com/nextdotid/proof_server/validator"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func before_each(t *testing.T) {
@@ -40,7 +40,7 @@ func Test_GeneratePostPayload(t *testing.T) {
 
 		das := generate()
 		result := das.GeneratePostPayload()
-		assert.Contains(t, result["default"], "%SIG_BASE64%")
+		require.Contains(t, result["default"], "%SIG_BASE64%")
 	})
 }
 
@@ -50,9 +50,10 @@ func Test_Validate(t *testing.T) {
 
 		das := generate()
 		das.Identity = "mItCHaTmASk.BiT"
-		assert.Nil(t, das.Validate())
-		assert.Greater(t, len(das.Signature), 10)
-		assert.Equal(t, "mitchatmask.bit", das.Identity)
+		require.Nil(t, das.Validate())
+		require.Greater(t, len(das.Signature), 10)
+		require.Equal(t, "mitchatmask.bit", das.Identity)
+		require.Equal(t, das.Identity, das.AltName)
 	})
 
 	// Do not test validation by ProofLocation, since it is unnecessary.

--- a/validator/discord/discord.go
+++ b/validator/discord/discord.go
@@ -103,6 +103,7 @@ func (dc *Discord) Validate() (err error) {
 		return xerrors.Errorf("User name mismatch: expect %s - actual %s", dc.Identity, msgResp.Author)
 	}
 
+	dc.AltName = msgResp.Author.ID
 	dc.Text = msgResp.Content
 	return dc.validateText()
 }

--- a/validator/discord/discord.go
+++ b/validator/discord/discord.go
@@ -103,7 +103,7 @@ func (dc *Discord) Validate() (err error) {
 		return xerrors.Errorf("User name mismatch: expect %s - actual %s", dc.Identity, msgResp.Author)
 	}
 
-	dc.AltName = msgResp.Author.ID
+	dc.AltID = msgResp.Author.ID
 	dc.Text = msgResp.Content
 	return dc.validateText()
 }

--- a/validator/discord/discord_test.go
+++ b/validator/discord/discord_test.go
@@ -41,6 +41,7 @@ func TestDiscord_Validate(t *testing.T) {
 		discord := generate()
 		err := discord.Validate()
 		assert.Nil(t, err)
+		t.Logf("AltName: %s", discord.AltName)
 	})
 	t.Run("different user", func(t *testing.T) {
 		before_each()

--- a/validator/discord/discord_test.go
+++ b/validator/discord/discord_test.go
@@ -41,7 +41,7 @@ func TestDiscord_Validate(t *testing.T) {
 		discord := generate()
 		err := discord.Validate()
 		assert.Nil(t, err)
-		t.Logf("AltName: %s", discord.AltID)
+		t.Logf("AltID: %s", discord.AltID)
 	})
 	t.Run("different user", func(t *testing.T) {
 		before_each()

--- a/validator/discord/discord_test.go
+++ b/validator/discord/discord_test.go
@@ -41,7 +41,7 @@ func TestDiscord_Validate(t *testing.T) {
 		discord := generate()
 		err := discord.Validate()
 		assert.Nil(t, err)
-		t.Logf("AltName: %s", discord.AltName)
+		t.Logf("AltName: %s", discord.AltID)
 	})
 	t.Run("different user", func(t *testing.T) {
 		before_each()

--- a/validator/dns/dns.go
+++ b/validator/dns/dns.go
@@ -128,7 +128,7 @@ func (dns *DNS) GenerateSignPayload() (payload string) {
 func (dns *DNS) Validate() (err error) {
 	// domain name is case-insensitive
 	dns.Identity = strings.ToLower(dns.Identity)
-	dns.AltName = dns.Identity
+	dns.AltID = dns.Identity
 	dns.SignaturePayload = dns.GenerateSignPayload()
 	query_resp, err := query(dns.Identity)
 	if err != nil {

--- a/validator/dns/dns.go
+++ b/validator/dns/dns.go
@@ -128,6 +128,7 @@ func (dns *DNS) GenerateSignPayload() (payload string) {
 func (dns *DNS) Validate() (err error) {
 	// domain name is case-insensitive
 	dns.Identity = strings.ToLower(dns.Identity)
+	dns.AltName = dns.Identity
 	dns.SignaturePayload = dns.GenerateSignPayload()
 	query_resp, err := query(dns.Identity)
 	if err != nil {

--- a/validator/dns/dns_test.go
+++ b/validator/dns/dns_test.go
@@ -17,13 +17,13 @@ func build() DNS {
 	createdAt, _ := util.TimestampStringToTime("1664267795")
 	return DNS{
 		Base: &validator.Base{
-			Platform:         types.Platforms.DNS,
-			Previous:         "",
-			Action:           types.Actions.Create,
-			Pubkey:           pk,
-			Identity:         "testcase.nextnext.id",
-			CreatedAt:        createdAt,
-			Uuid:             uuid.MustParse("80c98711-f4f6-43c7-b05c-8d86372f6131"),
+			Platform:  types.Platforms.DNS,
+			Previous:  "",
+			Action:    types.Actions.Create,
+			Pubkey:    pk,
+			Identity:  "testcase.nextnext.id",
+			CreatedAt: createdAt,
+			Uuid:      uuid.MustParse("80c98711-f4f6-43c7-b05c-8d86372f6131"),
 		},
 	}
 }
@@ -91,7 +91,7 @@ func Test_Validate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		dns := build()
 		require.NoError(t, dns.Validate())
-		require.Equal(t, dns.Identity, dns.AltName)
+		require.Equal(t, dns.Identity, dns.AltID)
 	})
 
 	t.Run("invalid", func(t *testing.T) {

--- a/validator/dns/dns_test.go
+++ b/validator/dns/dns_test.go
@@ -91,6 +91,7 @@ func Test_Validate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		dns := build()
 		require.NoError(t, dns.Validate())
+		require.Equal(t, dns.Identity, dns.AltName)
 	})
 
 	t.Run("invalid", func(t *testing.T) {

--- a/validator/ethereum/ethereum.go
+++ b/validator/ethereum/ethereum.go
@@ -69,6 +69,7 @@ func (et *Ethereum) GenerateSignPayload() (payload string) {
 func (et *Ethereum) Validate() (err error) {
 	et.SignaturePayload = et.GenerateSignPayload()
 	et.Identity = strings.ToLower(et.Identity)
+	et.AltName = et.Identity
 
 	switch et.Action {
 	case types.Actions.Create:

--- a/validator/ethereum/ethereum.go
+++ b/validator/ethereum/ethereum.go
@@ -69,7 +69,7 @@ func (et *Ethereum) GenerateSignPayload() (payload string) {
 func (et *Ethereum) Validate() (err error) {
 	et.SignaturePayload = et.GenerateSignPayload()
 	et.Identity = strings.ToLower(et.Identity)
-	et.AltName = et.Identity
+	et.AltID = et.Identity
 
 	switch et.Action {
 	case types.Actions.Create:

--- a/validator/ethereum/ethereum_test.go
+++ b/validator/ethereum/ethereum_test.go
@@ -83,7 +83,7 @@ func Test_Validate(t *testing.T) {
 
 		eth := generate()
 		require.Nil(t, eth.Validate())
-		require.Equal(t, eth.AltName, eth.Identity)
+		require.Equal(t, eth.AltID, eth.Identity)
 	})
 }
 

--- a/validator/ethereum/ethereum_test.go
+++ b/validator/ethereum/ethereum_test.go
@@ -15,7 +15,7 @@ import (
 
 	mycrypto "github.com/nextdotid/proof_server/util/crypto"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -61,7 +61,7 @@ func Test_GeneratePostPayload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		before_each(t)
 		eth := generate()
-		assert.Equal(t, "", eth.GeneratePostPayload()["default"])
+		require.Equal(t, "", eth.GeneratePostPayload()["default"])
 	})
 }
 
@@ -71,9 +71,9 @@ func Test_GenerateSignPayload(t *testing.T) {
 
 		eth := generate()
 		result := eth.GenerateSignPayload()
-		assert.Contains(t, result, "\"identity\":\""+strings.ToLower(crypto.PubkeyToAddress(wallet_sk.PublicKey).Hex()))
-		assert.Contains(t, result, "\"persona\":\"0x"+mycrypto.CompressedPubkeyHex(eth.Pubkey))
-		assert.Contains(t, result, "\"platform\":\"ethereum\"")
+		require.Contains(t, result, "\"identity\":\""+strings.ToLower(crypto.PubkeyToAddress(wallet_sk.PublicKey).Hex()))
+		require.Contains(t, result, "\"persona\":\"0x"+mycrypto.CompressedPubkeyHex(eth.Pubkey))
+		require.Contains(t, result, "\"platform\":\"ethereum\"")
 	})
 }
 
@@ -82,7 +82,8 @@ func Test_Validate(t *testing.T) {
 		before_each(t)
 
 		eth := generate()
-		assert.Nil(t, eth.Validate())
+		require.Nil(t, eth.Validate())
+		require.Equal(t, eth.AltName, eth.Identity)
 	})
 }
 
@@ -97,7 +98,7 @@ func Test_Validate_Delete(t *testing.T) {
 		}
 		eth.Signature, _ = mycrypto.SignPersonal([]byte(eth.GenerateSignPayload()), persona_sk)
 
-		assert.Nil(t, eth.Validate())
+		require.Nil(t, eth.Validate())
 	})
 
 	t.Run("signed by wallet", func(t *testing.T) {
@@ -110,7 +111,7 @@ func Test_Validate_Delete(t *testing.T) {
 			"wallet_signature": base64.StdEncoding.EncodeToString(wallet_sig),
 		}
 
-		assert.Nil(t, eth.Validate())
+		require.Nil(t, eth.Validate())
 	})
 
 	t.Run("signed by persona, but put in wallet_signature", func(t *testing.T) {
@@ -124,7 +125,7 @@ func Test_Validate_Delete(t *testing.T) {
 			"wallet_signature": base64.StdEncoding.EncodeToString(eth.Signature),
 		}
 
-		assert.NotNil(t, eth.Validate())
+		require.NotNil(t, eth.Validate())
 	})
 
 	t.Run("signed by wallet, but put in eth.Signature", func(t *testing.T) {
@@ -137,6 +138,6 @@ func Test_Validate_Delete(t *testing.T) {
 		eth.Signature, _ = mycrypto.SignPersonal([]byte(eth.GenerateSignPayload()), wallet_sk)
 		eth.Extra = map[string]string{}
 
-		assert.NotNil(t, eth.Validate())
+		require.NotNil(t, eth.Validate())
 	})
 }

--- a/validator/github/github.go
+++ b/validator/github/github.go
@@ -100,7 +100,7 @@ func (gh *Github) Validate() (err error) {
 	if gh.Identity != gist.Owner.GetLogin() {
 		return xerrors.Errorf("gist owner mismatch: should be %s, but got %s", gh.Identity, gist.Owner.GetLogin())
 	}
-	gh.AltName = strconv.FormatInt(gist.Owner.GetID(), 10)
+	gh.AltID = strconv.FormatInt(gist.Owner.GetID(), 10)
 
 	gist_filename := fmt.Sprintf("0x%s.json", crypto.CompressedPubkeyHex(gh.Pubkey))
 	files := gist.GetFiles()

--- a/validator/github/github.go
+++ b/validator/github/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/nextdotid/proof_server/types"
@@ -99,6 +100,7 @@ func (gh *Github) Validate() (err error) {
 	if gh.Identity != gist.Owner.GetLogin() {
 		return xerrors.Errorf("gist owner mismatch: should be %s, but got %s", gh.Identity, gist.Owner.GetLogin())
 	}
+	gh.AltName = strconv.FormatInt(gist.Owner.GetID(), 10)
 
 	gist_filename := fmt.Sprintf("0x%s.json", crypto.CompressedPubkeyHex(gh.Pubkey))
 	files := gist.GetFiles()

--- a/validator/github/github_test.go
+++ b/validator/github/github_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nextdotid/proof_server/util"
 	"github.com/nextdotid/proof_server/util/crypto"
 	"github.com/nextdotid/proof_server/validator"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -54,7 +54,8 @@ func Test_Validate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		github := generate()
 		err := github.Validate()
-		assert.Nil(t, err)
+		require.Nil(t, err)
+		require.Equal(t, "1191636", github.AltName)
 	})
 
 	t.Run("error if owner mismatch", func(t *testing.T) {
@@ -62,8 +63,8 @@ func Test_Validate(t *testing.T) {
 		github.Identity = "foobar"
 
 		err := github.Validate()
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "gist owner mismatch")
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "gist owner mismatch")
 	})
 
 	t.Run("error if gist is private", func(t *testing.T) {
@@ -71,7 +72,7 @@ func Test_Validate(t *testing.T) {
 		github.ProofLocation = "a8acd06e99ae6baa4939300fc170446c"
 
 		err := github.Validate()
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "not found or empty")
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "not found or empty")
 	})
 }

--- a/validator/github/github_test.go
+++ b/validator/github/github_test.go
@@ -55,7 +55,7 @@ func Test_Validate(t *testing.T) {
 		github := generate()
 		err := github.Validate()
 		require.Nil(t, err)
-		require.Equal(t, "1191636", github.AltName)
+		require.Equal(t, "1191636", github.AltID)
 	})
 
 	t.Run("error if owner mismatch", func(t *testing.T) {

--- a/validator/keybase/keybase.go
+++ b/validator/keybase/keybase.go
@@ -92,6 +92,7 @@ func (kb *Keybase) GenerateSignPayload() (payload string) {
 func (kb *Keybase) Validate() (err error) {
 	kb.Identity = strings.ToLower(kb.Identity)
 	kb.SignaturePayload = kb.GenerateSignPayload()
+	kb.AltName = kb.Identity // TODO: maybe get Keybase UserID in another API call?
 
 	url := fmt.Sprintf(URL, kb.Identity, mycrypto.CompressedPubkeyHex(kb.Pubkey))
 	kb.ProofLocation = url

--- a/validator/keybase/keybase.go
+++ b/validator/keybase/keybase.go
@@ -92,7 +92,7 @@ func (kb *Keybase) GenerateSignPayload() (payload string) {
 func (kb *Keybase) Validate() (err error) {
 	kb.Identity = strings.ToLower(kb.Identity)
 	kb.SignaturePayload = kb.GenerateSignPayload()
-	kb.AltName = kb.Identity // TODO: maybe get Keybase UserID in another API call?
+	kb.AltID = kb.Identity // TODO: maybe get Keybase UserID in another API call?
 
 	url := fmt.Sprintf(URL, kb.Identity, mycrypto.CompressedPubkeyHex(kb.Pubkey))
 	kb.ProofLocation = url

--- a/validator/keybase/keybase_test.go
+++ b/validator/keybase/keybase_test.go
@@ -10,7 +10,7 @@ import (
 	mycrypto "github.com/nextdotid/proof_server/util/crypto"
 	"github.com/nextdotid/proof_server/validator"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func before_each(t *testing.T) {
@@ -41,9 +41,9 @@ func Test_GeneratePostPayload(t *testing.T) {
 
 		kb := generate()
 		result := kb.GeneratePostPayload()
-		assert.Contains(t, result["default"], "To validate")
-		assert.Contains(t, result["default"], mycrypto.CompressedPubkeyHex(kb.Pubkey))
-		assert.Contains(t, result["default"], "%SIG_BASE64%")
+		require.Contains(t, result["default"], "To validate")
+		require.Contains(t, result["default"], mycrypto.CompressedPubkeyHex(kb.Pubkey))
+		require.Contains(t, result["default"], "%SIG_BASE64%")
 	})
 }
 
@@ -53,8 +53,9 @@ func Test_Validate(t *testing.T) {
 
 		kb := generate()
 		kb.Identity = "NYKma"
-		assert.Nil(t, kb.Validate())
-		assert.Greater(t, len(kb.Signature), 10)
-		assert.Equal(t, "nykma", kb.Identity)
+		require.Nil(t, kb.Validate())
+		require.Greater(t, len(kb.Signature), 10)
+		require.Equal(t, "nykma", kb.Identity)
+		require.Equal(t, kb.Identity, kb.AltName)
 	})
 }

--- a/validator/keybase/keybase_test.go
+++ b/validator/keybase/keybase_test.go
@@ -56,6 +56,6 @@ func Test_Validate(t *testing.T) {
 		require.Nil(t, kb.Validate())
 		require.Greater(t, len(kb.Signature), 10)
 		require.Equal(t, "nykma", kb.Identity)
-		require.Equal(t, kb.Identity, kb.AltName)
+		require.Equal(t, kb.Identity, kb.AltID)
 	})
 }

--- a/validator/main.go
+++ b/validator/main.go
@@ -30,6 +30,7 @@ type Base struct {
 	Pubkey   *ecdsa.PublicKey
 	// Identity on target platform.
 	Identity         string
+	AltName          string
 	ProofLocation    string
 	Signature        []byte
 	SignaturePayload string

--- a/validator/main.go
+++ b/validator/main.go
@@ -30,7 +30,7 @@ type Base struct {
 	Pubkey   *ecdsa.PublicKey
 	// Identity on target platform.
 	Identity         string
-	AltName          string
+	AltID            string
 	ProofLocation    string
 	Signature        []byte
 	SignaturePayload string

--- a/validator/minds/minds.go
+++ b/validator/minds/minds.go
@@ -148,7 +148,7 @@ func (minds *Minds) validatePayload(payload *MindsPayload) error {
 	if minds.Identity != strings.ToLower(entity.Owner.UserName) {
 		return xerrors.Errorf("Username mismatch: expect @%s, got @%s", minds.Identity, entity.Owner.UserName)
 	}
-	minds.AltName = entity.Owner.Guid
+	minds.AltID = entity.Owner.Guid
 
 	scanner := bufio.NewScanner(strings.NewReader(minds.Text))
 	for scanner.Scan() {

--- a/validator/minds/minds.go
+++ b/validator/minds/minds.go
@@ -148,6 +148,7 @@ func (minds *Minds) validatePayload(payload *MindsPayload) error {
 	if minds.Identity != strings.ToLower(entity.Owner.UserName) {
 		return xerrors.Errorf("Username mismatch: expect @%s, got @%s", minds.Identity, entity.Owner.UserName)
 	}
+	minds.AltName = entity.Owner.Guid
 
 	scanner := bufio.NewScanner(strings.NewReader(minds.Text))
 	for scanner.Scan() {

--- a/validator/minds/minds_test.go
+++ b/validator/minds/minds_test.go
@@ -71,5 +71,6 @@ func Test_Validate(t *testing.T) {
 
 		minds := generate()
 		require.NoError(t, minds.Validate())
+		require.Equal(t, "1302892485034381316", minds.AltName)
 	})
 }

--- a/validator/minds/minds_test.go
+++ b/validator/minds/minds_test.go
@@ -71,6 +71,6 @@ func Test_Validate(t *testing.T) {
 
 		minds := generate()
 		require.NoError(t, minds.Validate())
-		require.Equal(t, "1302892485034381316", minds.AltName)
+		require.Equal(t, "1302892485034381316", minds.AltID)
 	})
 }

--- a/validator/solana/solana.go
+++ b/validator/solana/solana.go
@@ -60,6 +60,7 @@ func (sol *Solana) Validate() (err error) {
 	// Wallet Sig encoded by Base58
 	// Persona Sig encoded by Base64
 	sol.SignaturePayload = sol.GenerateSignPayload()
+	sol.AltName = sol.Identity
 
 	switch sol.Action {
 	case types.Actions.Create:

--- a/validator/solana/solana.go
+++ b/validator/solana/solana.go
@@ -60,7 +60,7 @@ func (sol *Solana) Validate() (err error) {
 	// Wallet Sig encoded by Base58
 	// Persona Sig encoded by Base64
 	sol.SignaturePayload = sol.GenerateSignPayload()
-	sol.AltName = sol.Identity
+	sol.AltID = sol.Identity
 
 	switch sol.Action {
 	case types.Actions.Create:

--- a/validator/solana/solana_test.go
+++ b/validator/solana/solana_test.go
@@ -128,7 +128,7 @@ func Test_Validate_Delete(t *testing.T) {
 		sol.Signature, _ = mycrypto.SignPersonal([]byte(sol.GenerateSignPayload()), personaPriv)
 
 		require.NoError(t, sol.Validate())
-		require.Equal(t, sol.Identity, sol.AltName)
+		require.Equal(t, sol.Identity, sol.AltID)
 	})
 
 	t.Run("signed by wallet", func(t *testing.T) {

--- a/validator/solana/solana_test.go
+++ b/validator/solana/solana_test.go
@@ -15,7 +15,7 @@ import (
 
 	mycrypto "github.com/nextdotid/proof_server/util/crypto"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -65,7 +65,7 @@ func Test_GeneratePostPayload(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		before_each(t)
 		sol := generate()
-		assert.Equal(t, "", sol.GeneratePostPayload()["default"])
+		require.Equal(t, "", sol.GeneratePostPayload()["default"])
 	})
 }
 
@@ -75,10 +75,10 @@ func Test_GenerateSignPayload(t *testing.T) {
 
 		sol := generate()
 		result := sol.GenerateSignPayload()
-		assert.Contains(t, result, "\"identity\":\""+walletPriv.PublicKey().String())
-		assert.NotContains(t, result, "\"identity\":\""+strings.ToLower(walletPriv.PublicKey().String()))
-		assert.Contains(t, result, "\"persona\":\"0x"+mycrypto.CompressedPubkeyHex(sol.Pubkey))
-		assert.Contains(t, result, "\"platform\":\"solana\"")
+		require.Contains(t, result, "\"identity\":\""+walletPriv.PublicKey().String())
+		require.NotContains(t, result, "\"identity\":\""+strings.ToLower(walletPriv.PublicKey().String()))
+		require.Contains(t, result, "\"persona\":\"0x"+mycrypto.CompressedPubkeyHex(sol.Pubkey))
+		require.Contains(t, result, "\"platform\":\"solana\"")
 	})
 }
 
@@ -87,7 +87,7 @@ func Test_Validate(t *testing.T) {
 		before_each(t)
 
 		sol := generate()
-		assert.NoError(t, sol.Validate())
+		require.NoError(t, sol.Validate())
 	})
 
 	t.Run("fail with wrong wallet signature", func(t *testing.T) {
@@ -99,7 +99,7 @@ func Test_Validate(t *testing.T) {
 		}
 		sol.Signature, _ = mycrypto.SignPersonal([]byte(sol.GenerateSignPayload()), personaPriv)
 
-		assert.Error(t, sol.Validate())
+		require.Error(t, sol.Validate())
 	})
 
 	t.Run("fail with wrong persona signature", func(t *testing.T) {
@@ -112,7 +112,7 @@ func Test_Validate(t *testing.T) {
 		}
 		sol.Signature = []byte(uuid.New().String())
 
-		assert.Error(t, sol.Validate())
+		require.Error(t, sol.Validate())
 	})
 }
 
@@ -127,7 +127,8 @@ func Test_Validate_Delete(t *testing.T) {
 		}
 		sol.Signature, _ = mycrypto.SignPersonal([]byte(sol.GenerateSignPayload()), personaPriv)
 
-		assert.NoError(t, sol.Validate())
+		require.NoError(t, sol.Validate())
+		require.Equal(t, sol.Identity, sol.AltName)
 	})
 
 	t.Run("signed by wallet", func(t *testing.T) {
@@ -140,7 +141,7 @@ func Test_Validate_Delete(t *testing.T) {
 			"wallet_signature": walletSig.String(),
 		}
 
-		assert.NoError(t, sol.Validate())
+		require.NoError(t, sol.Validate())
 	})
 
 	t.Run("signed by persona, but with wrong wallet_signature", func(t *testing.T) {
@@ -153,7 +154,7 @@ func Test_Validate_Delete(t *testing.T) {
 			"wallet_signature": base58.Encode([]byte(uuid.New().String())),
 		}
 
-		assert.Error(t, sol.Validate())
+		require.Error(t, sol.Validate())
 	})
 
 	t.Run("signed by wallet, but with wrong persona sig, which should be ok", func(t *testing.T) {
@@ -167,6 +168,6 @@ func Test_Validate_Delete(t *testing.T) {
 			"wallet_signature": walletSig.String(),
 		}
 
-		assert.NoError(t, sol.Validate())
+		require.NoError(t, sol.Validate())
 	})
 }

--- a/validator/twitter/twitter.go
+++ b/validator/twitter/twitter.go
@@ -108,6 +108,7 @@ func (twitter *Twitter) Validate() (err error) {
 	}
 
 	twitter.Text = tweet.FullText
+	twitter.AltName = strconv.FormatInt(tweet.User.ID, 10)
 	return twitter.validateText()
 }
 

--- a/validator/twitter/twitter.go
+++ b/validator/twitter/twitter.go
@@ -108,7 +108,7 @@ func (twitter *Twitter) Validate() (err error) {
 	}
 
 	twitter.Text = tweet.FullText
-	twitter.AltName = strconv.FormatInt(tweet.User.ID, 10)
+	twitter.AltID = strconv.FormatInt(tweet.User.ID, 10)
 	return twitter.validateText()
 }
 

--- a/validator/twitter/twitter_test.go
+++ b/validator/twitter/twitter_test.go
@@ -74,7 +74,7 @@ func Test_Validate(t *testing.T) {
 		require.Greater(t, len(tweet.Text), 10)
 		require.NotEmpty(t, tweet.Text)
 		require.Equal(t, "yeiwb", tweet.Identity)
-		require.Equal(t, "1468853291941773312", tweet.AltName)
+		require.Equal(t, "1468853291941773312", tweet.AltID)
 	})
 
 	t.Run("success on encode base1024", func(t *testing.T) {

--- a/validator/twitter/twitter_test.go
+++ b/validator/twitter/twitter_test.go
@@ -10,7 +10,7 @@ import (
 	mycrypto "github.com/nextdotid/proof_server/util/crypto"
 	"github.com/nextdotid/proof_server/validator"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func before_each(t *testing.T) {
@@ -59,9 +59,9 @@ func Test_GeneratePostPayload(t *testing.T) {
 		before_each(t)
 		tweet := generate()
 		result := tweet.GeneratePostPayload()
-		assert.Contains(t, result["default"], "Verifying my Twitter ID")
-		assert.Contains(t, result["default"], tweet.Identity)
-		assert.Contains(t, result["default"], "%SIG_BASE64%")
+		require.Contains(t, result["default"], "Verifying my Twitter ID")
+		require.Contains(t, result["default"], tweet.Identity)
+		require.Contains(t, result["default"], "%SIG_BASE64%")
 	})
 }
 
@@ -70,19 +70,20 @@ func Test_Validate(t *testing.T) {
 		before_each(t)
 
 		tweet := generate()
-		assert.Nil(t, tweet.Validate())
-		assert.Greater(t, len(tweet.Text), 10)
-		assert.NotEmpty(t, tweet.Text)
-		assert.Equal(t, "yeiwb", tweet.Identity)
+		require.Nil(t, tweet.Validate())
+		require.Greater(t, len(tweet.Text), 10)
+		require.NotEmpty(t, tweet.Text)
+		require.Equal(t, "yeiwb", tweet.Identity)
+		require.Equal(t, "1468853291941773312", tweet.AltName)
 	})
 
 	t.Run("success on encode base1024", func(t *testing.T) {
 		before_each(t)
 		tweet := generateBase1024Encode()
-		assert.Nil(t, tweet.Validate())
-		assert.Greater(t, len(tweet.Text), 10)
-		assert.NotEmpty(t, tweet.Text)
-		assert.Equal(t, "sannieinmeta", tweet.Identity)
+		require.Nil(t, tweet.Validate())
+		require.Greater(t, len(tweet.Text), 10)
+		require.NotEmpty(t, tweet.Text)
+		require.Equal(t, "sannieinmeta", tweet.Identity)
 	})
 
 	t.Run("should return identity error", func(t *testing.T) {
@@ -90,13 +91,13 @@ func Test_Validate(t *testing.T) {
 
 		tweet := generate()
 		tweet.Identity = "foobar"
-		assert.NotNil(t, tweet.Validate())
+		require.NotNil(t, tweet.Validate())
 	})
 
 	t.Run("should return proof location not found", func(t *testing.T) {
 		before_each(t)
 		tweet := generate()
 		tweet.ProofLocation = "123456"
-		assert.NotNil(t, tweet.Validate())
+		require.NotNil(t, tweet.Validate())
 	})
 }


### PR DESCRIPTION
## Motivation
Many identity provider has both `username`-like and `user_id`-like identifier. We need to record both in case `username` is changed by the user after `vaildator.Validate()`.

To make this new system do a minimal impact on current behaviour, here's a modest change to start.

In the future, some of the `user_id`-based identifier should be put in `Identity` field, like `twitter`, `github`, `discord` and `minds`.

## Checklist
- [x] Models
  - [x] Proof
  - [x] ProofChain
- [x] validators
  - [x] `validator.Base` 