### PR TITLE
Feat: Switch to telegram public channels

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -51,9 +51,10 @@ type TwitterPlatformConfig struct {
 }
 
 type TelegramPlatformConfig struct {
-	ApiID    int    `json:"api_id"`
-	ApiHash  string `json:"api_hash"`
-	BotToken string `json:"bot_token"`
+	ApiID             int    `json:"api_id"`
+	ApiHash           string `json:"api_hash"`
+	BotToken          string `json:"bot_token"`
+	PublicChannelName string `json:"public_channel_name"`
 }
 
 type EthereumPlatformConfig struct {


### PR DESCRIPTION
### Description
Follow-up PR regarding #45 
To get this to work we need a simple bot forwarding user proofs to a public channel. There are a few open-source bots that could achieve this functionality.
The bot/validator could be configured to allow messages from multiple telegram channels.
