### PR TITLE
fix(worker): fix handler out tuple

### DIFF
--- a/cmd/lambda_worker/main.go
+++ b/cmd/lambda_worker/main.go
@@ -51,7 +51,7 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, sqs_event events.SQSEvent) events.SQSEventResponse {
+func handler(ctx context.Context, sqs_event events.SQSEvent) (events.SQSEventResponse, error) {
 	failures := []events.SQSBatchItemFailure{}
 	// Key: persona, Value: message id; persona as key to uniq
 	arweaveMsgs := map[string]string{}
@@ -96,7 +96,7 @@ func handler(ctx context.Context, sqs_event events.SQSEvent) events.SQSEventResp
 		failures = append(failures, arweaveFailed...)
 	}
 
-	return events.SQSEventResponse{BatchItemFailures: failures}
+	return events.SQSEventResponse{BatchItemFailures: failures}, nil
 }
 
 func arweave_upload_many(personas []string) error {

--- a/validator/ethereum/ethereum.go
+++ b/validator/ethereum/ethereum.go
@@ -67,7 +67,7 @@ func (et *Ethereum) GenerateSignPayload() (payload string) {
 
 // Both persona-signed and wallelt-signed request are vaild.
 func (et *Ethereum) Validate() (err error) {
-	if (et.SignaturePayload == "") {
+	if et.SignaturePayload == "" {
 		et.SignaturePayload = et.GenerateSignPayload()
 	}
 


### PR DESCRIPTION
it seems that it doesn't follow what`lambda.Start()` Rules say. https://github.com/aws/aws-lambda-go/blob/3dedc3285b5533729a20927fbf0fea1f1a167747/lambda/handler.go#L145